### PR TITLE
Drop all use of OSSpinLock

### DIFF
--- a/HJDanmaku/HJDanmakuView.swift
+++ b/HJDanmaku/HJDanmakuView.swift
@@ -709,10 +709,8 @@ extension HJDanmakuView {
             let cell = cellType.init(reuseIdentifier: identifier)
             return cell
         }
-        OSSpinLockLock(&reuseLock);
         let cell: HJDanmakuCell = cells!.lastObject! as! HJDanmakuCell
         cells!.removeLastObject()
-        OSSpinLockUnlock(&reuseLock);
         cell.zIndex = 0
         cell.prepareForReuse()
         return cell
@@ -720,14 +718,12 @@ extension HJDanmakuView {
     
     func recycleCellToReusePool(_ danmakuCell: HJDanmakuCell) {
         let identifier: String = danmakuCell.reuseIdentifier
-        OSSpinLockLock(&reuseLock);
         var cells = self.cellReusePool[identifier]
         if cells == nil {
             cells = NSMutableArray.init()
             self.cellReusePool[identifier] = cells
         }
         cells!.add(danmakuCell)
-        OSSpinLockUnlock(&reuseLock);
     }
     
 }


### PR DESCRIPTION
1. 可參考 [不再安全的 OSSpinLock](https://blog.ibireme.com/2016/01/16/spinlock_is_unsafe_in_ios/)
2. Apple 給予 [os_unfair_lock_lock](https://developer.apple.com/documentation/os/1646466-os_unfair_lock_lock?language=objc) 作為替代方案，但是只支援 iOS 10+
3. 使用效能也不差的 DispatchSemaphore 代替 
4.  `recycleCellToReusePool ` 已在 main thread 執行應該沒有加鎖必要