### PR TITLE
fix: prepare properly with empty danmakus array

### DIFF
--- a/HJDanmaku-Swift/HJDanmakuView.swift
+++ b/HJDanmaku-Swift/HJDanmakuView.swift
@@ -144,7 +144,7 @@ open class HJDanmakuView: UIView {
         self.isPrepared = false
         self.stop()
         
-        guard let danmakus = danmakus else {
+        guard let danmakus = danmakus, danmakus.count > 0 else {
             self.isPrepared = true
             onMainThreadAsync {
                 self.delegate?.prepareCompletedWithDanmakuView(self)


### PR DESCRIPTION
`prepareDanmakus` will not set `self.isPrepared = true` if the input is an empty array, so I modify it to make sure the `self.isPrepared = true`.